### PR TITLE
NAVQP-52: disconnect USB1 before booting Linux.

### DIFF
--- a/board/voxelbotics/navqp/navqp.c
+++ b/board/voxelbotics/navqp/navqp.c
@@ -462,6 +462,11 @@ int board_usb_cleanup(int index, enum usb_init_type init)
 	return ret;
 }
 
+void board_cleanup_before_linux()
+{
+	disconnect_from_pc();
+}
+
 #ifdef CONFIG_USB_TCPC
 /* Not used so far */
 int board_typec_get_mode(int index)


### PR DESCRIPTION
USB1 remains not fully disconnected from PC after 'fastboot 0' operation which leads to incorrect USB1 port initialization in the Linux kernel. This patch solves the problem.